### PR TITLE
Add root path

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,2 @@
+((nil
+  (cider-clojure-cli-global-options . "-A:dev")))

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: DeLaGuardo/setup-clojure@5.1
+      - uses: actions/checkout@v3
+      - uses: DeLaGuardo/setup-clojure@9.5
         with:
-          cli: 1.11.1.1113
+          cli: 1.11.1.1165
       - run: ./cypress/cypress.sh
         shell: bash

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ Query viewer and saved queries:
 ## Running
 
 To simply try it out, start repl with `:dev` alias:
-- eval `(start)`
-- eval `(some-docs)` to generate test docs
-- open http://localhost:3000/doc/%3Ahello in browser
+
+- eval `(start)` in your REPL
+- eval `(some-docs)` in your REPL to generate test docs
+- open [http://localhost:3000/doc/%3Ahello](http://localhost:3000/doc/%3Ahello) in browser
 
 Other way is to embed in an existing web application that
 uses XTDB. The `xtdb-inspector.core/inspector-handler` returns
@@ -35,7 +36,20 @@ monitoring reporter in the XTDB node config:
 :xtdb-inspector.metrics/reporter {}
 ```
 
+## Custom URI prefix
+
+Sometime (e.g., when embedding `xtdb-inspector` in another web application) there is a need for having all of its URLs prefixed. Simply set the environment variable `XTDB_INSPECTOR_URI_PREFIX`:
+
+- run `export XTDB_INSPECTOR_URI_PREFIX=/_inspector` in your shell
+- eval `(start)` in your REPL
+- eval `(some-docs)` in your REPL
+- open [http://localhost:3000/_inspector/doc/%3Ahello](http://localhost:3000/_inspector/doc/%3Ahello) in a browser.
+
+
 ## Changes
+
+### 2022-10-25
+- Support custom URI prefix
 
 ### 2022-10-19
 - Fix nested pull problem in query page

--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,13 @@
 {:paths ["src" "resources"]
  :deps {tatut/ripley {:git/url "https://github.com/tatut/ripley.git"
-                      :sha "bca327a81c0ee81a979a6bdeec533ea72483515e"}
+                      :sha "e33818ae6f93b2000d6b31929325070176048f65"}
         tatut/ripley-alpine {:git/url "https://github.com/tatut/ripley-alpine.git"
                              :sha "57d3f2cb99cd05c6579ba1d975bd0af858a64fdb"}
-        compojure/compojure {:mvn/version "1.7.0"}
-        http-kit/http-kit {:mvn/version "2.6.0"}
+        compojure/compojure {:mvn/version "1.6.1"}
+        http-kit/http-kit {:mvn/version "2.5.3"}
         com.xtdb/xtdb-core {:mvn/version "1.21.0"}
         com.xtdb/xtdb-metrics {:mvn/version "1.21.0"}
         com.xtdb/xtdb-lucene {:mvn/version "1.21.0"}}
  :aliases {:dev {:extra-paths ["dev-src"]
                  :extra-deps {com.xtdb/xtdb-http-server {:mvn/version "1.21.0"}
-                              dk.ative/docjure {:mvn/version "1.18.0"}}}}}
+                              dk.ative/docjure {:mvn/version "1.17.0"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,13 @@
 {:paths ["src" "resources"]
  :deps {tatut/ripley {:git/url "https://github.com/tatut/ripley.git"
-                      :sha "e33818ae6f93b2000d6b31929325070176048f65"}
+                      :sha "bca327a81c0ee81a979a6bdeec533ea72483515e"}
         tatut/ripley-alpine {:git/url "https://github.com/tatut/ripley-alpine.git"
                              :sha "57d3f2cb99cd05c6579ba1d975bd0af858a64fdb"}
-        compojure/compojure {:mvn/version "1.6.1"}
-        http-kit/http-kit {:mvn/version "2.5.3"}
-        com.xtdb/xtdb-core {:mvn/version "1.21.0"}
-        com.xtdb/xtdb-metrics {:mvn/version "1.21.0"}
-        com.xtdb/xtdb-lucene {:mvn/version "1.21.0"}}
+        compojure/compojure {:mvn/version "1.7.0"}
+        http-kit/http-kit {:mvn/version "2.6.0"}
+        com.xtdb/xtdb-core {:mvn/version "1.22.0"}
+        com.xtdb/xtdb-metrics {:mvn/version "1.22.0"}
+        com.xtdb/xtdb-lucene {:mvn/version "1.22.0"}}
  :aliases {:dev {:extra-paths ["dev-src"]
-                 :extra-deps {com.xtdb/xtdb-http-server {:mvn/version "1.21.0"}
-                              dk.ative/docjure {:mvn/version "1.17.0"}}}}}
+                 :extra-deps {com.xtdb/xtdb-http-server {:mvn/version "1.22.0"}
+                              dk.ative/docjure {:mvn/version "1.18.0"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -5,11 +5,9 @@
                              :sha "57d3f2cb99cd05c6579ba1d975bd0af858a64fdb"}
         compojure/compojure {:mvn/version "1.7.0"}
         http-kit/http-kit {:mvn/version "2.6.0"}
-        com.xtdb/xtdb-core {:mvn/version "1.22.0"}
-        com.xtdb/xtdb-metrics {:mvn/version "1.22.0"}
-        com.xtdb/xtdb-lucene {:mvn/version "1.22.0"}}
+        com.xtdb/xtdb-core {:mvn/version "1.21.0"}
+        com.xtdb/xtdb-metrics {:mvn/version "1.21.0"}
+        com.xtdb/xtdb-lucene {:mvn/version "1.21.0"}}
  :aliases {:dev {:extra-paths ["dev-src"]
                  :extra-deps {com.xtdb/xtdb-http-server {:mvn/version "1.22.0"}
-                              ;fipp/fipp {:mvn/version "0.6.26"}
-                              org.apache.logging.log4j/log4j-core {:mvn/version "2.17.1"}
                               dk.ative/docjure {:mvn/version "1.18.0"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -9,5 +9,5 @@
         com.xtdb/xtdb-metrics {:mvn/version "1.21.0"}
         com.xtdb/xtdb-lucene {:mvn/version "1.21.0"}}
  :aliases {:dev {:extra-paths ["dev-src"]
-                 :extra-deps {com.xtdb/xtdb-http-server {:mvn/version "1.22.0"}
+                 :extra-deps {com.xtdb/xtdb-http-server {:mvn/version "1.21.0"}
                               dk.ative/docjure {:mvn/version "1.18.0"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -10,6 +10,6 @@
         com.xtdb/xtdb-lucene {:mvn/version "1.22.0"}}
  :aliases {:dev {:extra-paths ["dev-src"]
                  :extra-deps {com.xtdb/xtdb-http-server {:mvn/version "1.22.0"}
-                              fipp/fipp {:mvn/version "0.6.26"}
+                              ;fipp/fipp {:mvn/version "0.6.26"}
                               org.apache.logging.log4j/log4j-core {:mvn/version "2.17.1"}
                               dk.ative/docjure {:mvn/version "1.18.0"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -10,4 +10,5 @@
         com.xtdb/xtdb-lucene {:mvn/version "1.22.0"}}
  :aliases {:dev {:extra-paths ["dev-src"]
                  :extra-deps {com.xtdb/xtdb-http-server {:mvn/version "1.22.0"}
+                              fipp/fipp {:mvn/version "0.6.26"}
                               dk.ative/docjure {:mvn/version "1.18.0"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -11,4 +11,5 @@
  :aliases {:dev {:extra-paths ["dev-src"]
                  :extra-deps {com.xtdb/xtdb-http-server {:mvn/version "1.22.0"}
                               fipp/fipp {:mvn/version "0.6.26"}
+                              org.apache.logging.log4j/log4j-core {:mvn/version "2.17.1"}
                               dk.ative/docjure {:mvn/version "1.18.0"}}}}}

--- a/dev-src/sales.clj
+++ b/dev-src/sales.clj
@@ -149,4 +149,7 @@
 (comment
   (load-sales-data @user/xtdb (str (System/getenv "HOME")
                                    "/Downloads/US_Regional_Sales_data.xlsx"))
-  (add-dashboard @user/xtdb))
+  (add-dashboard @user/xtdb)
+
+
+  :ok)

--- a/src/xtdb_inspector/core.clj
+++ b/src/xtdb_inspector/core.clj
@@ -11,12 +11,14 @@
             [xtdb-inspector.page.tx :as page.tx]
             [xtdb-inspector.page.dashboard :as page.dashboard]
             [ripley.live.context :as context]
-            [ring.middleware.params :as ring-params]))
+            [ring.middleware.params :as ring-params]
+            [fipp.edn :refer [pprint] :rename {pprint fipp}]))
 
 
 (defn- page [{wrap :wrap-page-fn :as ctx} req page-fn]
   (let [handler
         (fn [req]
+          (fipp [:page (select-keys req [:uri :websocket? :request-method :compojure/route])])
           (let [ctx (assoc ctx :request req)]
             (page/page-response
              ctx

--- a/src/xtdb_inspector/core.clj
+++ b/src/xtdb_inspector/core.clj
@@ -4,6 +4,7 @@
   (:require [org.httpkit.server :as http-kit]
             [compojure.core :refer [routes GET POST]]
             [compojure.route :as route]
+            [xtdb-inspector.util :refer [->route]]
             [xtdb-inspector.page :as page]
             [xtdb-inspector.page.doc :as page.doc]
             [xtdb-inspector.page.query :as page.query]
@@ -13,7 +14,6 @@
             [ripley.live.context :as context]
             [ring.middleware.params :as ring-params]
             [fipp.edn :refer [pprint] :rename {pprint fipp}]))
-
 
 (defn- page [{wrap :wrap-page-fn :as ctx} req page-fn]
   (let [handler
@@ -27,7 +27,6 @@
       (wrap req handler)
       (handler req))))
 
-
 (defn inspector-handler
   ([xtdb-node] (inspector-handler xtdb-node {}))
   ([xtdb-node {:keys [allow-editing? wrap-page-fn]
@@ -38,30 +37,29 @@
      (ring-params/wrap-params
       (routes
        (context/connection-handler "/__ripley-live" :ping-interval 45)
-       (GET "/doc" req
-            (page ctx req #'page.doc/render-form))
-       (GET "/doc/:doc-id" req
-            (page ctx req #'page.doc/render))
-       (GET "/query" req
-            (page ctx req #'page.query/render))
-       (POST "/query/export" req
-             (page.query/export-query ctx req))
-       (GET "/query/:query" req
-            (page ctx req #'page.query/render))
-       (GET "/attr" req
-            (page ctx req #'page.attr/render))
-       (GET "/attr/:keyword" req
-            (page ctx req #'page.attr/render))
-       (GET "/attr/:namespace/:keyword" req
-            (page ctx req #'page.attr/render))
-       (GET "/tx" req
-            (page ctx req #'page.tx/render))
-       (GET "/dashboard" req
-            (page ctx req #'page.dashboard/render-listing))
-       (GET "/dashboard/:dashboard" req
-            (page ctx req #'page.dashboard/render))
-       (route/resources "/"))))))
-
+       (GET (->route "/doc") req
+         (page ctx req #'page.doc/render-form))
+       (GET (->route "/doc/:doc-id") req
+         (page ctx req #'page.doc/render))
+       (GET (->route "/query") req
+         (page ctx req #'page.query/render))
+       (POST (->route "/query/export") req
+         (page.query/export-query ctx req))
+       (GET (->route "/query/:query") req
+         (page ctx req #'page.query/render))
+       (GET (->route "/attr") req
+         (page ctx req #'page.attr/render))
+       (GET (->route "/attr/:keyword") req
+         (page ctx req #'page.attr/render))
+       (GET (->route "/attr/:namespace/:keyword") req
+         (page ctx req #'page.attr/render))
+       (GET (->route "/tx") req
+         (page ctx req #'page.tx/render))
+       (GET (->route "/dashboard") req
+         (page ctx req #'page.dashboard/render-listing))
+       (GET (->route "/dashboard/:dashboard") req
+         (page ctx req #'page.dashboard/render))
+       (route/resources (->route "/")))))))
 
 (defn start [{:keys [port xtdb-node allow-editing?]
               :or {port 3000

--- a/src/xtdb_inspector/core.clj
+++ b/src/xtdb_inspector/core.clj
@@ -12,13 +12,12 @@
             [xtdb-inspector.page.tx :as page.tx]
             [xtdb-inspector.page.dashboard :as page.dashboard]
             [ripley.live.context :as context]
-            [ring.middleware.params :as ring-params]
-            [fipp.edn :refer [pprint] :rename {pprint fipp}]))
+            [ring.middleware.params :as ring-params]))
 
 (defn- page [{wrap :wrap-page-fn :as ctx} req page-fn]
   (let [handler
         (fn [req]
-          (fipp [:page (select-keys req [:uri :websocket? :request-method :compojure/route])])
+          #_(fipp [:page (select-keys req [:uri :websocket? :request-method :compojure/route])])
           (let [ctx (assoc ctx :request req)]
             (page/page-response
              ctx

--- a/src/xtdb_inspector/core.clj
+++ b/src/xtdb_inspector/core.clj
@@ -58,7 +58,7 @@
          (page ctx req #'page.dashboard/render-listing))
        (GET (->route "/dashboard/:dashboard") req
          (page ctx req #'page.dashboard/render))
-       (route/resources (->route "/")))))))
+       (route/resources "/"))))))
 
 (defn start [{:keys [port xtdb-node allow-editing?]
               :or {port 3000

--- a/src/xtdb_inspector/page.clj
+++ b/src/xtdb_inspector/page.clj
@@ -2,6 +2,7 @@
   "Main page template that sets up styles and app bar"
   (:require [ripley.html :as h]
             [xtdb-inspector.metrics :as metrics]
+            [xtdb-inspector.util :refer [root-path ->route]]
             [xtdb.api :as xt]
             [ripley.live.source :as source]
             [clojure.string :as str]
@@ -18,7 +19,7 @@
                           (fn [[e v a]]
                             ;; id, href, attr, value
                             [(pr-str e)
-                             (str "/doc/" (id/doc-id-param e))
+                             (str root-path "/doc/" (id/doc-id-param e))
                              (pr-str a)
                              (pr-str v)]) results)})
              results)
@@ -72,11 +73,11 @@
             [:td {:x-html "r[3]"}]]]]]]]))))
 
 (def links
-  [["/query" "Query"]
-   ["/doc" "Documents"]
-   ["/attr" "Attributes"]
-   ["/tx" "Transactions"]
-   ["/dashboard" "Dashboards"]])
+  [[(->route "/query") "Query"]
+   [(->route "/doc") "Documents"]
+   [(->route "/attr") "Attributes"]
+   [(->route "/tx") "Transactions"]
+   [(->route "/dashboard") "Dashboards"]])
 
 (defn app-bar [ctx search! results]
   (h/html

--- a/src/xtdb_inspector/page/attr.clj
+++ b/src/xtdb_inspector/page/attr.clj
@@ -4,7 +4,7 @@
             [ripley.html :as h]
             [xtdb-inspector.ui :as ui]
             [xtdb-inspector.ui.table :as ui.table]
-            [xtdb-inspector.util :refer [enc]]
+            [xtdb-inspector.util :refer [enc root-path]]
             [ripley.live.source :as source]
             [xtdb-inspector.id :as id]
             [xtdb-inspector.ui.tabs :as ui.tabs]
@@ -84,7 +84,7 @@
 (defn- render-attr-listing [{:keys [xtdb-node]}]
   (ui.table/table
    {:columns [{:label "Attribute" :accessor first
-               :render #(ui/link (str "/attr/" (enc (subs (str %) 1)))
+               :render #(ui/link (str root-path "/attr/" (enc (subs (str %) 1)))
                                  (pr-str %))}
               {:label "Values count" :accessor second}]
     :key first

--- a/src/xtdb_inspector/page/dashboard.clj
+++ b/src/xtdb_inspector/page/dashboard.clj
@@ -10,6 +10,7 @@
   (:require [ripley.html :as h]
             [xtdb.api :as xt]
             [xtdb-inspector.ui :as ui]
+            [xtdb-inspector.util :refer [root-path]]
             xtdb.query
             [ripley.live.source :as source]
             [xtdb-inspector.ui.chart :as ui.chart]
@@ -147,7 +148,7 @@
      [:div "Available dashboards:"
       [:ul
        [::h/for [[{:xtdb-inspector.dashboard/keys [name description]}] dashboards]
-        [:li (ui/link (str "/dashboard/" name) name) " " description]]
+        [:li (ui/link (str root-path "/dashboard/" name) name) " " description]]
        [::h/when (empty? dashboards)
         [:div.alert.alert-warning
          "No dashboards defined."]]]])))

--- a/src/xtdb_inspector/ui.clj
+++ b/src/xtdb_inspector/ui.clj
@@ -4,6 +4,7 @@
             [ripley.html :as h]
             [clojure.string :as str]
             [ripley.js :as js]
+            [xtdb-inspector.util :refer [root-path]]
             [xtdb-inspector.ui.edn :as ui.edn])
   (:import (java.time LocalDate LocalTime LocalDateTime Duration Instant)
            (java.time.format DateTimeFormatter FormatStyle)))
@@ -51,7 +52,7 @@
                                 (format-value is-id? v))}
                 value)
     (let [href (when (is-id? value)
-                 (str "/doc/" (id/doc-id-param value)))
+                 (str root-path "/doc/" (id/doc-id-param value)))
           disp (display value)
           custom-display? (not= ::no-custom-display disp)
           stringified (if-not custom-display?

--- a/src/xtdb_inspector/util.clj
+++ b/src/xtdb_inspector/util.clj
@@ -10,7 +10,7 @@
       (str/replace "+" "%20")))
 
 (def root-path
-  (or (System/getenv "XTDB_INSPECTOR_ROOT_PATH") "/i"))
+  (or (System/getenv "XTDB_INSPECTOR_ROOT_PATH") ""))
 
 (defn ->route
   [s]

--- a/src/xtdb_inspector/util.clj
+++ b/src/xtdb_inspector/util.clj
@@ -10,7 +10,7 @@
       (str/replace "+" "%20")))
 
 (def root-path
-  (or (System/getenv "XTDB_INSPECTOR_ROOT_PATH") ""))
+  (or (System/getenv "XTDB_INSPECTOR_URI_PREFIX") ""))
 
 (defn ->route
   [s]

--- a/src/xtdb_inspector/util.clj
+++ b/src/xtdb_inspector/util.clj
@@ -8,3 +8,10 @@
   (-> x
       URLEncoder/encode
       (str/replace "+" "%20")))
+
+(def root-path
+  (or (System/getenv "XTDB_INSPECTOR_ROOT_PATH") "/i"))
+
+(defn ->route
+  [s]
+  (str root-path s))


### PR DESCRIPTION
This PR adds the option of using a prefix for the URIs used by xtdb-inspector.
* environment variable XTDB_INSPECTOR_URI_PREFIX  to hold the prefix string if needed.